### PR TITLE
Add missing space that was causing an error

### DIFF
--- a/fs/var/www/cgi-bin/action.cgi
+++ b/fs/var/www/cgi-bin/action.cgi
@@ -281,7 +281,7 @@ if [ -n "$F_cmd" ]; then
       osdtext=$(printf '%b' "${F_osdtext//%/\\x}")
       osdtext=$(echo "$osdtext" | sed -e "s/\\+/ /g")
 
-      if [ ! -z "$axis_enable"];then
+      if [ ! -z "$axis_enable" ]; then
         update_axis
         osdtext="${osdtext} ${AXIS}"
         echo "DISPLAY_AXIS=true" > /opt/config/osd.conf


### PR DESCRIPTION
This was caught by shellcheck.  A space was missing before the `]` and causing the if statement to fail with a syntax error