### PR TITLE
Fix typo in S02factory

### DIFF
--- a/fs/etc/init.d/S02factory
+++ b/fs/etc/init.d/S02factory
@@ -23,8 +23,7 @@ case "$1" in
 
 			#nvram commit
 		else
-			[ "$(nvram get rtdev fw_version)" != "$(cat /opt/version)" ] && nvram set rtde
-v fw_version "$(cat /opt/version)"
+			[ "$(nvram get rtdev fw_version)" != "$(cat /opt/version)" ] && nvram set rtdev fw_version "$(cat /opt/version)"
 			
 			# restore the SSL certifcate
 			nvram get rtdev certificate > "/etc/ssl/lighttpd.pem"


### PR DESCRIPTION
Fixed a typo in S02factory init script that prevents lighttpd from starting.