### PR TITLE
Update uEnv.txt for WYZEC2

### DIFF
--- a/fs/uEnv.txt
+++ b/fs/uEnv.txt
@@ -1,6 +1,6 @@
 baudrate=115200
 bootargs=console=ttyS1,115200n8 mem=40M@0x0 ispmem=8M@0x2800000 rmem=16M@0x3000000 init=/linuxrc root=/dev/mmcblk0p1 rootwait rootfstype=ext3 rw mtdparts=jz_sfc:256k(boot),2560k(kernel),7104k(rootfs),6336k(data),64k(config),64k(factory),-(flag)
-bootcmd=ext4load mmc 0:1 0x80600000 /boot/uImage.lzma;bootm 0x80600000
+bootcmd=ext4load mmc 0:1 0x80600000 /boot/uImage.lzma;gpio clear 43;bootm 0x80600000
 bootdelay=1
 stderr=serial
 stdin=serial


### PR DESCRIPTION
Adding gpio clear 43 to bootcmd allows openfang rc5 to boot on WYZEC2 (Wyze Cam V2)