### PR TITLE
SXJ02ZM: Add fixes for filter, yellow led, night mode

### DIFF
--- a/fs/etc/init.d/S45fang
+++ b/fs/etc/init.d/S45fang
@@ -81,11 +81,12 @@ start | "")
 
 	#autonight -D /dev/jz_adc_aux_0 -d 1 -O 600 -F 650 &
 
-	# set solid yellow led
+	# Set Yellow led
+	yellow_led_state="$(nvram get 2860 yellow_led_state)"
 	echo none >/sys/class/leds/led_yellow/trigger
-	echo 1 >/sys/class/leds/led_yellow/brightness
+	echo $yellow_led_state >/sys/class/leds/led_yellow/brightness
 	echo none >/sys/class/leds/led_yellow1/trigger
-	echo 1 >/sys/class/leds/led_yellow1/brightness
+	echo $yellow_led_state >/sys/class/leds/led_yellow1/brightness
 
 	;;
 

--- a/fs/usr/sbin/setmodel
+++ b/fs/usr/sbin/setmodel
@@ -90,6 +90,10 @@ nvram set 2860 "rtsp.en_audio" ""
 	cp -f /uEnv_64.txt /uEnv.txt;
 	#check if mtd partitions are right for this model
 	[ "$(cat /proc/mtd | grep 'mtd4: 00010000 00008000 "config"')" != "" ] && { nvram commit; echo "ok"; exit 0; }
+
+	# Set IR filter pins
+	nvram set 2860 ir_filter_pin1 26
+	nvram set 2860 ir_filter_pin2 25
 }
 
 echo "nok"

--- a/fs/usr/sbin/setmodel
+++ b/fs/usr/sbin/setmodel
@@ -19,6 +19,9 @@ nvram set 2860 "rtsp.port" 8554
 nvram set 2860 "rtsp.stream" 0
 nvram set 2860 "rtsp.en_audio" ""
 
+# Set default led state
+nvram set 2860 yellow_led_state 1
+
 # Xiaomi Dafang, Wyze Cam Pan
 # mtdparts=jz_sfc:256k(boot),2048k(kernel),3392k(root),640k(driver),4736k(appfs),2048k(backupk),640k(backupd),2048k(backupa),256k(config),256k(para),-(flag)
 { [ "$model" = "DF3" ] || [ "$model" = "WYZECP1" ]; } && {

--- a/fs/var/www/cgi-bin/action.cgi
+++ b/fs/var/www/cgi-bin/action.cgi
@@ -340,6 +340,14 @@ if [ -n "$F_cmd" ]; then
       /usr/bin/setconf -k n -v 0
     ;;
 
+    night-mode-on)
+      night_mode on
+    ;;
+
+    night-mode-off)
+      night_mode off
+    ;;
+
     flip-on)
       /usr/bin/setconf -k f -v 1
     ;;


### PR DESCRIPTION
Signed-off-by: Yevhen Fastiuk <yevfast@gmail.com>

Device:
Mi Home Security Camera Basic 1080P (SXJ02ZM) (mijia.camera.v3)

This PR contains the next items:
* Add HTTP actions to enable/disable night-mode
* Fix filter pins for SXJ02ZM camera (It is reversed for this cam at least)
* Add nvram state for yellow led.

Usage:
* Enable/disable night-mode
```
curl -k "https://<camera-ip>/cgi-bin/action.cgi?cmd=night-mode-on"
curl -k "https://<camera-ip>/cgi-bin/action.cgi?cmd=night-mode-off"
```
* Change yellow led state to off (1 for on)
```
nvram set 2860 yellow_led_state 0
```